### PR TITLE
make isRead true for viewed imap mails

### DIFF
--- a/source/uMailItems.pas
+++ b/source/uMailItems.pas
@@ -106,7 +106,7 @@ end;
 function TMailItem.isRead(const accountIsImap : boolean): boolean;
 begin
   if accountIsImap then // todo: AND use server status
-    result := self.Seen
+    result := self.Seen or self.Viewed;
   else
     result := self.Viewed;
 


### PR DESCRIPTION
A proposal to fix bug no. 5 from this report: https://sourceforge.net/p/poptrayu/discussion/bugs/thread/5b4fa9eb/ when "Reset Mail Count in Tray when Viewing" is enabled.